### PR TITLE
Portfolio

### DIFF
--- a/app/views/welcome/index.html.erb
+++ b/app/views/welcome/index.html.erb
@@ -1,6 +1,1 @@
 <h1>Welcome Index</h1>
-<% if current_user %>
-  <%= link_to "Log Out", '/logout', method: :delete %>
-<% else %>
-  <%= link_to 'Login', '/login' %>
-<% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,3 +2,4 @@ Portfolio.destroy_all
 
 Portfolio.create(name: "Traditional")
 Portfolio.create(name: "Digital", description: "This portfolio consists of digital artwork")
+User.create(username: "admin", password: "password", role: 1)

--- a/spec/features/users/admin_login_spec.rb
+++ b/spec/features/users/admin_login_spec.rb
@@ -5,11 +5,7 @@ RSpec.describe "Admin login Screen" do
 
     admin = User.create(username: "admin", password: "password", role: 1)
 
-    visit "/"
-
-    click_on "Login"
-
-    expect(current_path).to eq("/login")
+    visit "/login"
 
     fill_in :username, with: "#{admin.username}"
     fill_in :password, with: "#{admin.password}"
@@ -23,9 +19,7 @@ RSpec.describe "Admin login Screen" do
   it "cannot log in with bad credentials" do
     admin = User.create(username: "admin", password: "password", role: 1)
 
-    visit "/"
-
-    click_on "Login"
+    visit "/login"
 
     fill_in :username, with: admin.username
     fill_in :password, with: "incorrect password"
@@ -39,9 +33,7 @@ RSpec.describe "Admin login Screen" do
   it "admin can log out" do
     admin = User.create(username: "admin", password: "password", role: 1)
 
-    visit "/"
-
-    click_on "Login"
+    visit "/login"
 
     fill_in :username, with: admin.username
     fill_in :password, with: admin.password
@@ -50,10 +42,10 @@ RSpec.describe "Admin login Screen" do
     expect(current_path).to eq('/admin/dashboard')
 
     visit '/'
+
     click_link "Log Out"
 
     expect(current_path).to eq('/')
-    expect(page).to have_content('Login')
     expect(page).not_to have_content('Log Out')
   end
 end


### PR DESCRIPTION
Remove login links from app. Admin must navigate to `/login` in order to log in.